### PR TITLE
feat: enable http for otel

### DIFF
--- a/example.yaml
+++ b/example.yaml
@@ -132,7 +132,7 @@ insert:
     traces_table: otel_traces
 
 
-# Settings related to exporting data as OTLP to an OpenTelemetry endpoint over gRPC.
+# Settings related to exporting data as OTLP to an OpenTelemetry endpoint.
 # When enabled, the exporter consumes the same generated/replayed blocks the insert
 # workers would and sends them as OTLP instead of inserting into ClickHouse. Only one
 # sink (insert or otel) can consume the block queue at a time — if both are enabled,
@@ -140,12 +140,20 @@ insert:
 # (column values map straight to OTLP fields; no SDK enrichment).
 otel:
   enabled: false
-  # OTLP/gRPC endpoint. A leading http:// / https:// / grpc:// scheme is optional;
-  # http:// implies plaintext.
+  # OTLP transport: grpc (default, typically port 4317) or http (OTLP/HTTP with a
+  # protobuf payload, typically port 4318).
+  protocol: grpc
+  # OTLP endpoint.
+  #   grpc: a host:port such as localhost:4317. A leading http:// / https:// /
+  #         grpc:// scheme is optional; http:// implies plaintext.
+  #   http: the base endpoint such as https://localhost:4318. The per-signal path
+  #         (/v1/logs or /v1/traces) is appended automatically. If no scheme is
+  #         given, https is used unless insecure is true.
   url: localhost:4317
-  # Disable transport security (plaintext gRPC). Set true for a local collector.
+  # Disable transport security (plaintext gRPC, or http:// for the http transport).
+  # An explicit scheme in url takes precedence over this flag.
   insecure: true
-  # Concurrent exporter workers (one gRPC connection each).
+  # Concurrent exporter workers (one connection each).
   threads: 4
   # Rows accumulated across one or more blocks before an export is flushed. Not an
   # exact limit — a batch finishes on the block boundary that crosses this threshold.
@@ -154,9 +162,10 @@ otel:
   flush_interval: 1s
   # Per-export request timeout.
   timeout: 30s
-  # gRPC compression: none or gzip.
+  # Compression: none or gzip. For http this gzips the request body.
   compression: gzip
-  # Optional gRPC metadata headers sent with every export (e.g. auth tokens).
+  # Optional headers sent with every export (gRPC metadata or HTTP headers, e.g.
+  # auth tokens).
   headers:
     # authorization: "Bearer <token>"
 

--- a/internal/otel/client.go
+++ b/internal/otel/client.go
@@ -16,9 +16,29 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
-// client is a thin OTLP/gRPC export client. It holds one gRPC connection and the
-// logs and traces service clients (only one is used per exporter run).
-type client struct {
+// exporter is the transport-agnostic OTLP export client. Both the gRPC and HTTP
+// implementations send the same typed OTLP request messages; only the wire
+// transport differs.
+type exporter interface {
+	exportLogs(ctx context.Context, req *collogspb.ExportLogsServiceRequest) error
+	exportTraces(ctx context.Context, req *coltracepb.ExportTraceServiceRequest) error
+	close() error
+}
+
+// dial creates the export client for the configured protocol. The connection is
+// lazy where possible, so this generally only fails on invalid configuration.
+func dial(cfg *Config) (exporter, error) {
+	switch cfg.protocol() {
+	case protocolHTTP:
+		return dialHTTP(cfg)
+	default:
+		return dialGRPC(cfg)
+	}
+}
+
+// grpcClient is a thin OTLP/gRPC export client. It holds one gRPC connection and
+// the logs and traces service clients (only one is used per exporter run).
+type grpcClient struct {
 	conn    *grpc.ClientConn
 	logs    collogspb.LogsServiceClient
 	traces  coltracepb.TraceServiceClient
@@ -26,9 +46,9 @@ type client struct {
 	timeout time.Duration
 }
 
-// dial creates a lazy gRPC client. grpc.NewClient does not open a connection
+// dialGRPC creates a lazy gRPC client. grpc.NewClient does not open a connection
 // until the first RPC, so this only fails on invalid configuration.
-func dial(cfg *Config) (*client, error) {
+func dialGRPC(cfg *Config) (*grpcClient, error) {
 	target, plaintext := parseTarget(cfg.URL)
 	if cfg.Insecure {
 		plaintext = true
@@ -49,7 +69,7 @@ func dial(cfg *Config) (*client, error) {
 		return nil, fmt.Errorf("failed to create grpc client for %q: %w", target, err)
 	}
 
-	c := &client{
+	c := &grpcClient{
 		conn:    conn,
 		logs:    collogspb.NewLogsServiceClient(conn),
 		traces:  coltracepb.NewTraceServiceClient(conn),
@@ -61,21 +81,21 @@ func dial(cfg *Config) (*client, error) {
 	return c, nil
 }
 
-func (c *client) exportLogs(ctx context.Context, req *collogspb.ExportLogsServiceRequest) error {
+func (c *grpcClient) exportLogs(ctx context.Context, req *collogspb.ExportLogsServiceRequest) error {
 	ctx, cancel := c.callContext(ctx)
 	defer cancel()
 	_, err := c.logs.Export(ctx, req)
 	return err
 }
 
-func (c *client) exportTraces(ctx context.Context, req *coltracepb.ExportTraceServiceRequest) error {
+func (c *grpcClient) exportTraces(ctx context.Context, req *coltracepb.ExportTraceServiceRequest) error {
 	ctx, cancel := c.callContext(ctx)
 	defer cancel()
 	_, err := c.traces.Export(ctx, req)
 	return err
 }
 
-func (c *client) callContext(ctx context.Context) (context.Context, context.CancelFunc) {
+func (c *grpcClient) callContext(ctx context.Context) (context.Context, context.CancelFunc) {
 	if c.md != nil {
 		ctx = metadata.NewOutgoingContext(ctx, c.md)
 	}
@@ -85,7 +105,7 @@ func (c *client) callContext(ctx context.Context) (context.Context, context.Canc
 	return context.WithCancel(ctx)
 }
 
-func (c *client) close() error {
+func (c *grpcClient) close() error {
 	return c.conn.Close()
 }
 

--- a/internal/otel/client_http.go
+++ b/internal/otel/client_http.go
@@ -1,0 +1,162 @@
+package otel
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	collogspb "go.opentelemetry.io/proto/otlp/collector/logs/v1"
+	coltracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
+	"google.golang.org/protobuf/proto"
+)
+
+// httpClient is an OTLP/HTTP export client. It POSTs protobuf-encoded OTLP
+// requests to the per-signal paths ("/v1/logs", "/v1/traces") of the configured
+// endpoint. The request messages are the same ones the gRPC client sends; only
+// the transport differs.
+type httpClient struct {
+	http      *http.Client
+	logsURL   string
+	tracesURL string
+	headers   map[string]string
+	gzip      bool
+	timeout   time.Duration
+}
+
+func dialHTTP(cfg *Config) (*httpClient, error) {
+	base, err := httpBaseURL(cfg.URL, cfg.Insecure)
+	if err != nil {
+		return nil, err
+	}
+
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	if base.Scheme == "https" {
+		transport.TLSClientConfig = &tls.Config{}
+	}
+
+	return &httpClient{
+		http:      &http.Client{Transport: transport},
+		logsURL:   signalURL(base, "/v1/logs"),
+		tracesURL: signalURL(base, "/v1/traces"),
+		headers:   cfg.Headers,
+		gzip:      cfg.Compression == "gzip",
+		timeout:   cfg.Timeout,
+	}, nil
+}
+
+func (c *httpClient) exportLogs(ctx context.Context, req *collogspb.ExportLogsServiceRequest) error {
+	return c.post(ctx, c.logsURL, req)
+}
+
+func (c *httpClient) exportTraces(ctx context.Context, req *coltracepb.ExportTraceServiceRequest) error {
+	return c.post(ctx, c.tracesURL, req)
+}
+
+// post marshals msg as OTLP protobuf and POSTs it. A non-2xx response is
+// returned as an error so the worker's retry/backoff loop handles transient
+// failures (429/503) the same way it handles gRPC errors.
+func (c *httpClient) post(ctx context.Context, endpoint string, msg proto.Message) error {
+	body, err := proto.Marshal(msg)
+	if err != nil {
+		return fmt.Errorf("marshal otlp request: %w", err)
+	}
+
+	encoding := ""
+	if c.gzip {
+		var buf bytes.Buffer
+		zw := gzip.NewWriter(&buf)
+		if _, err := zw.Write(body); err != nil {
+			return fmt.Errorf("gzip otlp request: %w", err)
+		}
+		if err := zw.Close(); err != nil {
+			return fmt.Errorf("gzip otlp request: %w", err)
+		}
+		body = buf.Bytes()
+		encoding = "gzip"
+	}
+
+	if c.timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, c.timeout)
+		defer cancel()
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	// Custom headers first, then the protocol-required headers so they can't be
+	// clobbered by user config.
+	for k, v := range c.headers {
+		req.Header.Set(k, v)
+	}
+	req.Header.Set("Content-Type", "application/x-protobuf")
+	if encoding != "" {
+		req.Header.Set("Content-Encoding", encoding)
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	// Read a snippet for diagnostics, then drain the rest so the connection can
+	// be reused.
+	snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	if resp.StatusCode/100 != 2 {
+		return fmt.Errorf("otlp/http export to %s failed: %s: %s", endpoint, resp.Status, strings.TrimSpace(string(snippet)))
+	}
+	return nil
+}
+
+func (c *httpClient) close() error {
+	c.http.CloseIdleConnections()
+	return nil
+}
+
+// httpBaseURL normalizes the configured URL into an absolute http(s) base URL.
+// A bare "host:port" gets a scheme inferred from the insecure flag; an explicit
+// scheme in the URL always takes precedence over the flag.
+func httpBaseURL(raw string, insecure bool) (*url.URL, error) {
+	if !strings.Contains(raw, "://") {
+		scheme := "https"
+		if insecure {
+			scheme = "http"
+		}
+		raw = scheme + "://" + raw
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		return nil, fmt.Errorf("invalid otel url %q: %w", raw, err)
+	}
+	switch u.Scheme {
+	case "http", "https":
+	default:
+		return nil, fmt.Errorf("invalid otel url scheme %q (want http or https)", u.Scheme)
+	}
+	if u.Host == "" {
+		return nil, fmt.Errorf("invalid otel url %q: missing host", raw)
+	}
+	return u, nil
+}
+
+// signalURL appends the per-signal path (e.g. "/v1/logs") to the base endpoint,
+// unless the base path already ends with it.
+func signalURL(base *url.URL, signalPath string) string {
+	u := *base
+	p := strings.TrimRight(u.Path, "/")
+	if !strings.HasSuffix(p, signalPath) {
+		p += signalPath
+	}
+	u.Path = p
+	return u.String()
+}

--- a/internal/otel/client_http_test.go
+++ b/internal/otel/client_http_test.go
@@ -1,0 +1,136 @@
+package otel
+
+import (
+	"compress/gzip"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	collogspb "go.opentelemetry.io/proto/otlp/collector/logs/v1"
+	logspb "go.opentelemetry.io/proto/otlp/logs/v1"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestSignalURL(t *testing.T) {
+	cases := []struct {
+		raw       string
+		insecure  bool
+		wantLogs  string
+		wantTrace string
+	}{
+		{"https://localhost:4318", false, "https://localhost:4318/v1/logs", "https://localhost:4318/v1/traces"},
+		{"localhost:4318", true, "http://localhost:4318/v1/logs", "http://localhost:4318/v1/traces"},
+		{"localhost:4318", false, "https://localhost:4318/v1/logs", "https://localhost:4318/v1/traces"},
+		{"http://localhost:4318/", false, "http://localhost:4318/v1/logs", "http://localhost:4318/v1/traces"},
+		{"https://collector.example.com/otlp", false, "https://collector.example.com/otlp/v1/logs", "https://collector.example.com/otlp/v1/traces"},
+		// An explicit scheme wins over the insecure flag.
+		{"https://localhost:4318", true, "https://localhost:4318/v1/logs", "https://localhost:4318/v1/traces"},
+	}
+	for _, c := range cases {
+		base, err := httpBaseURL(c.raw, c.insecure)
+		if err != nil {
+			t.Fatalf("httpBaseURL(%q): %v", c.raw, err)
+		}
+		if got := signalURL(base, "/v1/logs"); got != c.wantLogs {
+			t.Errorf("signalURL(%q) logs = %q, want %q", c.raw, got, c.wantLogs)
+		}
+		if got := signalURL(base, "/v1/traces"); got != c.wantTrace {
+			t.Errorf("signalURL(%q) traces = %q, want %q", c.raw, got, c.wantTrace)
+		}
+	}
+}
+
+func TestHTTPExportLogsRoundTrip(t *testing.T) {
+	for _, useGzip := range []bool{false, true} {
+		var gotPath, gotContentType, gotEncoding, gotAuth string
+		var gotReq collogspb.ExportLogsServiceRequest
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotPath = r.URL.Path
+			gotContentType = r.Header.Get("Content-Type")
+			gotEncoding = r.Header.Get("Content-Encoding")
+			gotAuth = r.Header.Get("Authorization")
+
+			var body io.Reader = r.Body
+			if gotEncoding == "gzip" {
+				zr, err := gzip.NewReader(r.Body)
+				if err != nil {
+					t.Errorf("gzip.NewReader: %v", err)
+					http.Error(w, "bad gzip", http.StatusBadRequest)
+					return
+				}
+				body = zr
+			}
+			raw, _ := io.ReadAll(body)
+			if err := proto.Unmarshal(raw, &gotReq); err != nil {
+				t.Errorf("proto.Unmarshal: %v", err)
+			}
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer srv.Close()
+
+		compression := ""
+		if useGzip {
+			compression = "gzip"
+		}
+		cfg := &Config{
+			Protocol:    protocolHTTP,
+			URL:         srv.URL,
+			Compression: compression,
+			Headers:     map[string]string{"Authorization": "Bearer tok"},
+		}
+		c, err := dialHTTP(cfg)
+		if err != nil {
+			t.Fatalf("dialHTTP: %v", err)
+		}
+
+		req := &collogspb.ExportLogsServiceRequest{
+			ResourceLogs: []*logspb.ResourceLogs{{
+				ScopeLogs: []*logspb.ScopeLogs{{
+					LogRecords: []*logspb.LogRecord{{TimeUnixNano: 42}},
+				}},
+			}},
+		}
+		if err := c.exportLogs(context.Background(), req); err != nil {
+			t.Fatalf("exportLogs (gzip=%v): %v", useGzip, err)
+		}
+
+		if gotPath != "/v1/logs" {
+			t.Errorf("path = %q, want /v1/logs", gotPath)
+		}
+		if gotContentType != "application/x-protobuf" {
+			t.Errorf("content-type = %q", gotContentType)
+		}
+		if useGzip && gotEncoding != "gzip" {
+			t.Errorf("content-encoding = %q, want gzip", gotEncoding)
+		}
+		if !useGzip && gotEncoding != "" {
+			t.Errorf("content-encoding = %q, want empty", gotEncoding)
+		}
+		if gotAuth != "Bearer tok" {
+			t.Errorf("authorization = %q", gotAuth)
+		}
+		if len(gotReq.ResourceLogs) != 1 ||
+			gotReq.ResourceLogs[0].ScopeLogs[0].LogRecords[0].TimeUnixNano != 42 {
+			t.Errorf("decoded request mismatch: %+v", &gotReq)
+		}
+	}
+}
+
+func TestHTTPExportNon2xxErrors(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "service unavailable", http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	c, err := dialHTTP(&Config{Protocol: protocolHTTP, URL: srv.URL})
+	if err != nil {
+		t.Fatalf("dialHTTP: %v", err)
+	}
+	err = c.exportLogs(context.Background(), &collogspb.ExportLogsServiceRequest{})
+	if err == nil {
+		t.Fatal("expected error on 503 response, got nil")
+	}
+}

--- a/internal/otel/config.go
+++ b/internal/otel/config.go
@@ -5,23 +5,32 @@ import (
 	"time"
 )
 
-// Config controls the OTLP/gRPC exporter. When enabled, the exporter consumes
+// Config controls the OTLP exporter. When enabled, the exporter consumes
 // blocks from the same queue the insert workers use and exports them as OTLP to
 // an OpenTelemetry endpoint instead of inserting into ClickHouse. Only one sink
 // (insert or otel) can consume the queue at a time.
 type Config struct {
 	Enabled bool `yaml:"enabled"`
 
-	// URL is the OTLP/gRPC endpoint, e.g. "localhost:4317". A leading
-	// "http://" / "https://" / "grpc://" scheme is accepted and stripped.
+	// Protocol selects the OTLP transport: "grpc" (default) or "http". "http" is
+	// OTLP/HTTP with a protobuf payload (typically port 4318), "grpc" is
+	// OTLP/gRPC (typically port 4317).
+	Protocol string `yaml:"protocol"`
+
+	// URL is the OTLP endpoint. For gRPC this is a host:port, e.g.
+	// "localhost:4317"; a leading "http://" / "https://" / "grpc://" scheme is
+	// accepted and stripped. For HTTP this is the base endpoint, e.g.
+	// "https://localhost:4318"; the per-signal path ("/v1/logs" or "/v1/traces")
+	// is appended automatically unless the URL already ends in one.
 	URL string `yaml:"url"`
 
-	// Insecure disables transport security (plaintext gRPC). When false, TLS is
-	// used. A "http://" scheme in URL also implies insecure.
+	// Insecure disables transport security (plaintext gRPC, or http:// for the
+	// HTTP transport). When false, TLS is used. A "http://" scheme in URL also
+	// implies insecure; a scheme in URL takes precedence over this flag.
 	Insecure bool `yaml:"insecure"`
 
 	// Threads is the number of concurrent exporter workers. Each worker holds one
-	// gRPC connection and consumes blocks independently.
+	// connection and consumes blocks independently.
 	Threads int `yaml:"threads"`
 
 	// BatchSize is the number of rows accumulated (across one or more blocks)
@@ -35,17 +44,30 @@ type Config struct {
 	// Timeout is the per-export-request deadline. Defaults to 30s.
 	Timeout time.Duration `yaml:"timeout"`
 
-	// Compression is the gRPC compressor to use: "gzip" or "" / "none".
+	// Compression is the compressor to use: "gzip" or "" / "none". For gRPC this
+	// selects the gRPC compressor; for HTTP it gzips the request body.
 	Compression string `yaml:"compression"`
 
-	// Headers are optional gRPC metadata sent with every export (e.g. auth tokens).
+	// Headers are optional headers sent with every export (gRPC metadata or HTTP
+	// request headers, e.g. auth tokens).
 	Headers map[string]string `yaml:"headers"`
 }
 
 const (
+	protocolGRPC = "grpc"
+	protocolHTTP = "http"
+
 	defaultFlushInterval = time.Second
 	defaultTimeout       = 30 * time.Second
 )
+
+// protocol returns the configured transport, defaulting to gRPC when unset.
+func (c Config) protocol() string {
+	if c.Protocol == "" {
+		return protocolGRPC
+	}
+	return c.Protocol
+}
 
 // withDefaults returns a copy of the config with zero-valued tunables filled in.
 func (c Config) withDefaults() Config {
@@ -63,6 +85,11 @@ func (c Config) Validate() error {
 		return nil
 	}
 
+	switch c.Protocol {
+	case "", protocolGRPC, protocolHTTP:
+	default:
+		return errors.New("protocol must be one of: grpc, http")
+	}
 	if c.URL == "" {
 		return errors.New("must set url")
 	}

--- a/internal/otel/scheduler.go
+++ b/internal/otel/scheduler.go
@@ -12,7 +12,8 @@ import (
 )
 
 // Scheduler manages the OTLP exporter worker goroutines. Each worker consumes
-// blocks from the shared queue, converts them to OTLP, and exports over gRPC.
+// blocks from the shared queue, converts them to OTLP, and exports over the
+// configured transport (gRPC or HTTP).
 type Scheduler struct {
 	log       *slog.Logger
 	workerLog *slog.Logger

--- a/internal/otel/worker.go
+++ b/internal/otel/worker.go
@@ -23,7 +23,7 @@ type batch interface {
 	len() int
 	// flush exports the accumulated rows and returns the wire size and row
 	// count sent. The batch is NOT reset on error so the caller can decide.
-	flush(ctx context.Context, c *client) (bytesSent, rows int, err error)
+	flush(ctx context.Context, c exporter) (bytesSent, rows int, err error)
 	// reset clears the accumulated rows.
 	reset()
 }
@@ -47,7 +47,7 @@ func (lb *logsBatch) addBlock(blk block.SharedColumns) {
 
 func (lb *logsBatch) len() int { return lb.b.len() }
 
-func (lb *logsBatch) flush(ctx context.Context, c *client) (int, int, error) {
+func (lb *logsBatch) flush(ctx context.Context, c exporter) (int, int, error) {
 	req := lb.b.build()
 	size := proto.Size(req)
 	rows := lb.b.len()
@@ -78,7 +78,7 @@ func (tb *tracesBatch) addBlock(blk block.SharedColumns) {
 
 func (tb *tracesBatch) len() int { return tb.b.len() }
 
-func (tb *tracesBatch) flush(ctx context.Context, c *client) (int, int, error) {
+func (tb *tracesBatch) flush(ctx context.Context, c exporter) (int, int, error) {
 	req := tb.b.build()
 	size := proto.Size(req)
 	rows := tb.b.len()
@@ -149,7 +149,7 @@ func (w *worker) Run(ctx context.Context) error {
 	}
 	defer func() {
 		if closeErr := c.close(); closeErr != nil {
-			w.log.Debug("failed to close grpc client", "err", closeErr)
+			w.log.Debug("failed to close exporter client", "err", closeErr)
 		}
 	}()
 


### PR DESCRIPTION
Adds an http protocol to the otel section, enabling otlp to be sent via http